### PR TITLE
Emit TIFF tags after extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Utility function to extract metadata from a TIFF file:
 famdo extract <path-to-tiff> [--out <out-path>]
 ```
 
+The extracted JSON reports each TIFF tag with its numeric TIFF `id`, human-readable
+`tag` name, raw `value`, and TIFF value `type`. The numeric `id` is the stable
+cross-tool identifier and should be preferred when building connector mappings.
+
 ### Metadata Editing
 Update a single field in an existing FAMH JSON document:
 

--- a/src/commands/extract.rs
+++ b/src/commands/extract.rs
@@ -43,6 +43,7 @@ pub fn extract_tiff_metadata_tags<R: std::io::Read + std::io::Seek>(
             Ok((tag, ifd_value)) => {
                 let (value, value_type) = extract_value(&ifd_value);
                 tags.push(json!({
+                    "id": tag.to_u16(),
                     "tag": format!("{tag:?}"),
                     "value": value,
                     "type": value_type,
@@ -154,5 +155,10 @@ mod tests {
         let dims = &metadata["dimensions"];
         assert_eq!(dims["width"], json!(640));
         assert_eq!(dims["height"], json!(480));
+
+        let tags = metadata["tags"].as_array().unwrap();
+        assert!(!tags.is_empty());
+        assert!(tags.iter().all(|tag| tag["id"].is_u64()));
+        assert!(tags.iter().all(|tag| tag.get("tag").is_some()));
     }
 }


### PR DESCRIPTION
Extracted metadata now includes TIFF tags with their numeric IDs, human-readable names, raw values, and value types, enhancing the metadata output for better integration and mapping.